### PR TITLE
update vendored redcon to latest

### DIFF
--- a/vendor/github.com/tidwall/redcon/README.md
+++ b/vendor/github.com/tidwall/redcon/README.md
@@ -7,7 +7,7 @@
 <a href="https://godoc.org/github.com/tidwall/redcon"><img src="https://img.shields.io/badge/api-reference-blue.svg?style=flat-square" alt="GoDoc"></a>
 </p>
 
-<p align="center">Fast Redis compatible server framework for Go</a></p>
+<p align="center">Fast Redis compatible server framework for Go</p>
 
 Redcon is a custom Redis server framework for Go that is fast and simple to use. The reason for this library it to give an efficient server front-end for the [BuntDB](https://github.com/tidwall/buntdb) and [Tile38](https://github.com/tidwall/tile38) projects.
 


### PR DESCRIPTION
I was reading the redcon vendored with summitdb, with an eye
towards securing the traffic with ssh, and I happened to notice that it wasn't
up to date with the latest redcon. Is there any reason not to update it?

This PR updates the vendored redcon to latest / 582fbf0957692a0b78d6e28a53a1313641ec994c