### PR TITLE
FENCEGET reads a fencing token without changing it. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Fencing Tokens
 A fencing token is simply a number that increases. 
 It's guaranteed to be consistent across the cluster and can never be deleted or decreased. 
 The value is a 64-bit unsigned integer. The first FENCE call will return "1".
-This can be useful in applications that need things like distributed locking and preventing race conditions.
+This can be useful in applications that need things like distributed locking and preventing race conditions. FENCEGET will read the token without incrementing it.
 
 ```
 > FENCE mytoken
@@ -224,6 +224,10 @@ This can be useful in applications that need things like distributed locking and
 "2"
 > FENCE mytoken
 "3"
+> FENCEGET mytoken
+"3"
+> FENCE mytoken
+"4"
 ```
 
 
@@ -336,6 +340,7 @@ Below is the complete list of commands.
 [EXPIRE](https://github.com/tidwall/summitdb/wiki/EXPIRE),
 [EXPIREAT](https://github.com/tidwall/summitdb/wiki/EXPIREAT),
 [FENCE](https://github.com/tidwall/summitdb/wiki/FENCE),
+[FENCEGET](https://github.com/tidwall/summitdb/wiki/FENCEGET),
 [FLUSHDB](https://github.com/tidwall/summitdb/wiki/FLUSHDB),
 [GET](https://github.com/tidwall/summitdb/wiki/GET), 
 [GETBIT](https://github.com/tidwall/summitdb/wiki/GETBIT), 

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -381,6 +381,9 @@ func (m *Machine) doScriptableCommand(a finn.Applier, conn redcon.Conn, cmd redc
 	case "fence":
 		// FENCE token
 		return m.doFence(a, conn, cmd, tx)
+	case "fenceget":
+		// FENCEGET token
+		return m.doFenceGet(a, conn, cmd, tx)
 	case "backup":
 		// BACKUP [STATUS]
 		return m.doBackup(a, conn, cmd, tx)

--- a/machine/transactions_test.go
+++ b/machine/transactions_test.go
@@ -164,9 +164,13 @@ func transactions_GET_test(mc *mockCluster) error {
 
 func transactions_FENCE_test(mc *mockCluster) error {
 	return mc.DoBatch([][]interface{}{
+		{"FENCEGET", "mytoken1"}, {"0"},
+		{"FENCEGET", "mytoken2"}, {"0"},
 		{"FENCE", "mytoken1"}, {"1"},
 		{"FENCE", "mytoken1"}, {"2"},
+		{"FENCEGET", "mytoken1"}, {"2"},
 		{"FENCE", "mytoken1"}, {"3"},
+		{"FENCEGET", "mytoken1"}, {"3"},
 		{"FENCE", "mytoken1"}, {"4"},
 		{"FENCE", "mytoken1"}, {"5"},
 		{"FENCE", "mytoken2"}, {"1"},
@@ -174,14 +178,19 @@ func transactions_FENCE_test(mc *mockCluster) error {
 		{"FENCE", "mytoken2"}, {"3"},
 		{"FENCE", "mytoken2"}, {"4"},
 		{"FENCE", "mytoken2"}, {"5"},
+		{"FENCEGET", "mytoken2"}, {"5"},
 	})
 	return mc.DoBatch([][]interface{}{
+		{"FENCEGET", "mytoken1"}, {"5"},
+		{"FENCEGET", "mytoken2"}, {"5"},
 		{"FENCE", "mytoken1"}, {"6"},
 		{"FENCE", "mytoken1"}, {"7"},
 		{"FENCE", "mytoken1"}, {"8"},
 		{"FENCE", "mytoken1"}, {"9"},
+		{"FENCEGET", "mytoken1"}, {"9"},
 		{"FENCE", "mytoken1"}, {"10"},
 		{"FENCE", "mytoken2"}, {"6"},
+		{"FENCEGET", "mytoken2"}, {"6"},
 		{"FENCE", "mytoken2"}, {"7"},
 		{"FENCE", "mytoken2"}, {"8"},
 		{"FENCE", "mytoken2"}, {"9"},


### PR DESCRIPTION
Fixes #10

The corresponding wiki doc update can be pulled from https://github.com/glycerine/summitdb.wiki.git, commit eed34163e83255f31ff8eed904baff5adaf2c055