### PR TITLE
length option to FENCE, to support batch updates and dedup

### DIFF
--- a/machine/server.go
+++ b/machine/server.go
@@ -64,6 +64,9 @@ func (m *Machine) doFence(a finn.Applier, conn redcon.Conn, cmd redcon.Command, 
 		if err != nil {
 			return nil, err
 		}
+		if incr < 1 {
+			return nil, fmt.Errorf("length argument to FENCE must be > 0")
+		}
 	}
 	key := sdbMetaPrefix + "fence:" + string(cmd.Args[1])
 	return m.writeDoApply(a, conn, cmd, tx, func(tx *buntdb.Tx) (interface{}, error) {

--- a/machine/transactions_test.go
+++ b/machine/transactions_test.go
@@ -163,7 +163,7 @@ func transactions_GET_test(mc *mockCluster) error {
 }
 
 func transactions_FENCE_test(mc *mockCluster) error {
-	return mc.DoBatch([][]interface{}{
+	err := mc.DoBatch([][]interface{}{
 		{"FENCEGET", "mytoken1"}, {"0"},
 		{"FENCEGET", "mytoken2"}, {"0"},
 		{"FENCE", "mytoken1"}, {"1"},
@@ -180,7 +180,10 @@ func transactions_FENCE_test(mc *mockCluster) error {
 		{"FENCE", "mytoken2"}, {"5"},
 		{"FENCEGET", "mytoken2"}, {"5"},
 	})
-	return mc.DoBatch([][]interface{}{
+	if err != nil {
+		return err
+	}
+	err = mc.DoBatch([][]interface{}{
 		{"FENCEGET", "mytoken1"}, {"5"},
 		{"FENCEGET", "mytoken2"}, {"5"},
 		{"FENCE", "mytoken1"}, {"6"},
@@ -196,4 +199,17 @@ func transactions_FENCE_test(mc *mockCluster) error {
 		{"FENCE", "mytoken2"}, {"9"},
 		{"FENCE", "mytoken2"}, {"10"},
 	})
+	if err != nil {
+		return err
+	}
+	// check: FENCE token length
+	err = mc.DoBatch([][]interface{}{
+		{"FENCEGET", "mytoken1"}, {"10"},
+		{"FENCEGET", "mytoken2"}, {"10"},
+		{"FENCE", "mytoken1", "20"}, {"30"},
+		{"FENCE", "mytoken2", "5"}, {"15"},
+		{"FENCEGET", "mytoken1"}, {"30"},
+		{"FENCEGET", "mytoken2"}, {"15"},
+	})
+	return err
 }


### PR DESCRIPTION
Use case: as an application developer, I want to generate a sequentially numbered (gapless) log of my appends to a particular stream. For efficiency sake, I want to append batches rather than record by record.  Given that I know my batch size, I want to ask summitdb for a reservation of that size. This will allow me to detect duplicate writes.

Background: after reviewing 

a) https://github.com/tidwall/summitdb/issues/5

and

b) https://groups.google.com/forum/#!msg/raft-dev/5YJ3l1Dp8PI/qsnpba5cYZoJ

it seemed apparent that a client writing to summitdb will need to reserve a span in the sequence of its stream (simply an ordered array of records) in order to deduplicate writes. 

Hence the length option to FENCE supports the client reserving a block in the sequence for subsequent append. 

The client can then number its submission (assigning essentially an externally visible log sequence number or lsn), and on read does a deduplication operation using those lsn. 

This handles the case when the raft implementation has falsely told a writer that it failed, and thus the writer wrote again/more than once to the data stream. 

According to a) and b) above, this is a possibility that will happen in the raft (and most any distributed system) and thus must be handled at the application level by recognizing the duplication of appended data.