### PR TITLE
Add ARM to the list of platforms built

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you want to try the latest version, you can build SummitDB from the master br
 
 ### Building SummitDB
 
-SummitDB can be compiled and used on Linux, OSX, Windows, FreeBSD, and probably others since the codebase is 100% Go. We support both 32 bit and 64 bit systems. Go must be installed on the build machine.
+SummitDB can be compiled and used on Linux, OSX, Windows, FreeBSD, ARM (Raspberry PI) and probably others since the codebase is 100% Go. We support both 32 bit and 64 bit systems. Go must be installed on the build machine.
 
 To build simply:
 

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -56,6 +56,7 @@ if [ "$1" == "package" ]; then
 	package "Windows" "windows" "amd64"
 	package "Mac" "darwin" "amd64"
 	package "Linux" "linux" "amd64"
+	package "ARM" "linux" "arm"
 	package "FreeBSD" "freebsd" "amd64"
 	exit
 fi


### PR DESCRIPTION
Summit runs great on the Raspberry PI and this PR builds a linux/arm package by default.